### PR TITLE
Direct client calls replacing bravado.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(name='wes-service',
       install_requires=[
           'future',
           'connexion==1.4.2',
-          'bravado==10.1.0',
           'ruamel.yaml >= 0.12.4, < 0.15',
           'cwlref-runner==1.0',
           'schema-salad>=2.6, <3',

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -30,7 +30,7 @@ class IntegrationTest(unittest.TestCase):
 
         # client for the swagger API methods
         cls.client = WESClient({'auth': '', 'proto': 'http', 'host': 'localhost:8080'})
-        
+
         # manual test (wdl only working locally atm)
         cls.manual = False
 
@@ -58,14 +58,14 @@ class IntegrationTest(unittest.TestCase):
                                           json_input=self.cwl_json_input,
                                           workflow_attachment=self.cwl_attachments)
         self.assertTrue(check_for_file(outfile_path), 'Output file was not found: ' + str(outfile_path))
-    
+
     def test_local_md5sum(self):
         """LOCAL md5sum cwl to the wes-service server, and check for the correct output."""
         outfile_path, run_id = self.run_md5sum(wf_input=self.cwl_local_path,
                                                json_input=self.cwl_json_input,
                                                workflow_attachment=self.cwl_attachments)
         self.assertTrue(check_for_file(outfile_path), 'Output file was not found: ' + str(outfile_path))
-    
+
     def test_run_attachments(self):
         """LOCAL md5sum cwl to the wes-service server, check for attachments."""
         outfile_path, run_id = self.run_md5sum(wf_input=self.cwl_local_path,

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -5,11 +5,10 @@ import time
 import os
 import subprocess32 as subprocess
 import signal
-import requests
 import shutil
 import logging
 
-from wes_client.util import build_wes_request
+from wes_client.util import WESClient
 
 logging.basicConfig(level=logging.INFO)
 
@@ -28,6 +27,9 @@ class IntegrationTest(unittest.TestCase):
         cls.wdl_local_path = os.path.abspath('testdata/md5sum.wdl')
         cls.wdl_json_input = "file://" + os.path.abspath('testdata/md5sum.wdl.json')
         cls.wdl_attachments = ['file://' + os.path.abspath('testdata/md5sum.input')]
+
+        # houses the API methods
+        cls.client = WESClient({'auth': '', 'proto': 'http', 'host': 'localhost:8080'})
         
         # manual test (wdl only working locally atm)
         cls.manual = False
@@ -52,44 +54,35 @@ class IntegrationTest(unittest.TestCase):
 
     def test_dockstore_md5sum(self):
         """HTTP md5sum cwl (dockstore), run it on the wes-service server, and check for the correct output."""
-        outfile_path, _ = run_md5sum(wf_input=self.cwl_dockstore_url,
-                                     json_input=self.cwl_json_input,
-                                     workflow_attachment=self.cwl_attachments)
+        outfile_path, _ = self.run_md5sum(wf_input=self.cwl_dockstore_url,
+                                          json_input=self.cwl_json_input,
+                                          workflow_attachment=self.cwl_attachments)
         self.assertTrue(check_for_file(outfile_path), 'Output file was not found: ' + str(outfile_path))
     
     def test_local_md5sum(self):
         """LOCAL md5sum cwl to the wes-service server, and check for the correct output."""
-        outfile_path, run_id = run_md5sum(wf_input=self.cwl_local_path,
-                                          json_input=self.cwl_json_input,
-                                          workflow_attachment=self.cwl_attachments)
+        outfile_path, run_id = self.run_md5sum(wf_input=self.cwl_local_path,
+                                               json_input=self.cwl_json_input,
+                                               workflow_attachment=self.cwl_attachments)
         self.assertTrue(check_for_file(outfile_path), 'Output file was not found: ' + str(outfile_path))
     
     def test_run_attachments(self):
         """LOCAL md5sum cwl to the wes-service server, check for attachments."""
-        outfile_path, run_id = run_md5sum(wf_input=self.cwl_local_path,
-                                          json_input=self.cwl_json_input,
-                                          workflow_attachment=self.cwl_attachments)
-        get_response = get_log_request(run_id)["request"]
+        outfile_path, run_id = self.run_md5sum(wf_input=self.cwl_local_path,
+                                               json_input=self.cwl_json_input,
+                                               workflow_attachment=self.cwl_attachments)
+        get_response = self.client.get_run_log(run_id)["request"]
         self.assertTrue(check_for_file(outfile_path), 'Output file was not found: ' + get_response["workflow_attachment"])
         attachment_tool_path = get_response["workflow_attachment"][7:] + "/dockstore-tool-md5sum.cwl"
         self.assertTrue(check_for_file(attachment_tool_path), 'Attachment file was not found: ' + get_response["workflow_attachment"])
 
 
-def run_md5sum(wf_input, json_input, workflow_attachment=None):
-    """Pass a local md5sum cwl to the wes-service server, and return the path of the output file that was created."""
-    endpoint = 'http://localhost:8080/ga4gh/wes/v1/runs'
-    parts = build_wes_request(wf_input,
-                              json_input,
-                              attachments=workflow_attachment)
-    response = requests.post(endpoint, files=parts).json()
-    assert 'run_id' in response, str(response.json())
-    output_dir = os.path.abspath(os.path.join('workflows', response['run_id'], 'outdir'))
-    return os.path.join(output_dir, 'md5sum.txt'), response['run_id']
-
-
-def get_log_request(run_id):
-    endpoint = 'http://localhost:8080/ga4gh/wes/v1/runs/{}'.format(run_id)
-    return requests.get(endpoint).json()
+    def run_md5sum(self, wf_input, json_input, workflow_attachment=None):
+        """Pass a local md5sum cwl to the wes-service server, and return the path of the output file that was created."""
+        response = self.client.run(wf_input, json_input, workflow_attachment)
+        assert 'run_id' in response, str(response.json())
+        output_dir = os.path.abspath(os.path.join('workflows', response['run_id'], 'outdir'))
+        return os.path.join(output_dir, 'md5sum.txt'), response['run_id']
 
 
 def get_server_pids():

--- a/wes_client/util.py
+++ b/wes_client/util.py
@@ -1,6 +1,6 @@
 import os
 import json
-from bravado.requests_client import RequestsClient
+import requests
 import urllib
 import logging
 import schema_salad.ref_resolver
@@ -102,7 +102,6 @@ class WESClient(object):
         self.auth = service['auth']
         self.proto = service['proto']
         self.host = service['host']
-        self.http_client = RequestsClient()
 
     def get_service_info(self):
         """
@@ -118,8 +117,8 @@ class WESClient(object):
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
         :return: The body of the get result as a dictionary.
         """
-        postresult = self.http_client.session.get("%s://%s/ga4gh/wes/v1/service-info" % (self.proto, self.host),
-                                                  headers={"Authorization": self.auth})
+        postresult = requests.get("%s://%s/ga4gh/wes/v1/service-info" % (self.proto, self.host),
+                                  headers={"Authorization": self.auth})
         return wes_reponse(postresult)
 
     def list_runs(self):
@@ -135,8 +134,8 @@ class WESClient(object):
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
         :return: The body of the get result as a dictionary.
         """
-        postresult = self.http_client.session.get("%s://%s/ga4gh/wes/v1/runs" % (self.proto, self.host),
-                                                  headers={"Authorization": self.auth})
+        postresult = requests.get("%s://%s/ga4gh/wes/v1/runs" % (self.proto, self.host),
+                                  headers={"Authorization": self.auth})
         return wes_reponse(postresult)
 
     def run(self, wf, jsonyaml, attachments):
@@ -154,52 +153,52 @@ class WESClient(object):
         :return: The body of the post result as a dictionary.
         """
         parts = build_wes_request(wf, jsonyaml, attachments)
-        postresult = self.http_client.session.post("%s://%s/ga4gh/wes/v1/runs" % (self.proto, self.host),
-                                                   files=parts,
-                                                   headers={"Authorization": self.auth})
+        postresult = requests.post("%s://%s/ga4gh/wes/v1/runs" % (self.proto, self.host),
+                                   files=parts,
+                                   headers={"Authorization": self.auth})
         return wes_reponse(postresult)
 
     def cancel(self, run_id):
         """
         Cancel a running workflow.
 
-        :param run_id:
+        :param run_id: String (typically a uuid) identifying the run.
         :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
         :return: The body of the delete result as a dictionary.
         """
-        postresult = self.http_client.session.delete("%s://%s/ga4gh/wes/v1/runs/%s" % (self.proto, self.host, run_id),
-                                                     headers={"Authorization": self.auth})
+        postresult = requests.delete("%s://%s/ga4gh/wes/v1/runs/%s" % (self.proto, self.host, run_id),
+                                     headers={"Authorization": self.auth})
         return wes_reponse(postresult)
 
     def get_run_log(self, run_id):
         """
         Get detailed info about a running workflow.
 
-        :param run_id:
+        :param run_id: String (typically a uuid) identifying the run.
         :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
         :return: The body of the get result as a dictionary.
         """
-        postresult = self.http_client.session.get("%s://%s/ga4gh/wes/v1/runs/%s" % (self.proto, self.host, run_id),
-                                                  headers={"Authorization": self.auth})
+        postresult = requests.get("%s://%s/ga4gh/wes/v1/runs/%s" % (self.proto, self.host, run_id),
+                                  headers={"Authorization": self.auth})
         return wes_reponse(postresult)
 
     def get_run_status(self, run_id):
         """
         Get quick status info about a running workflow.
 
-        :param run_id:
+        :param run_id: String (typically a uuid) identifying the run.
         :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
         :return: The body of the get result as a dictionary.
         """
-        postresult = self.http_client.session.get("%s://%s/ga4gh/wes/v1/runs/%s/status" % (self.proto, self.host, run_id),
-                                             headers={"Authorization": self.auth})
+        postresult = requests.get("%s://%s/ga4gh/wes/v1/runs/%s/status" % (self.proto, self.host, run_id),
+                                  headers={"Authorization": self.auth})
         return wes_reponse(postresult)

--- a/wes_client/util.py
+++ b/wes_client/util.py
@@ -111,7 +111,6 @@ class WESClient(object):
         WES API versions supported, and information about general
         the service availability.
 
-        :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
@@ -128,7 +127,6 @@ class WESClient(object):
         live updates as the user traverses the pages, the behavior
         should be decided (and documented) by each implementation.
 
-        :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
@@ -145,7 +143,6 @@ class WESClient(object):
         :param str workflow_file: A local/http/https path to a cwl/wdl/python workflow file.
         :param str jsonyaml: A local path to a json or yaml file.
         :param list attachments: A list of local paths to files that will be uploaded to the server.
-        :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
@@ -163,7 +160,6 @@ class WESClient(object):
         Cancel a running workflow.
 
         :param run_id: String (typically a uuid) identifying the run.
-        :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
@@ -178,7 +174,6 @@ class WESClient(object):
         Get detailed info about a running workflow.
 
         :param run_id: String (typically a uuid) identifying the run.
-        :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)
@@ -193,7 +188,6 @@ class WESClient(object):
         Get quick status info about a running workflow.
 
         :param run_id: String (typically a uuid) identifying the run.
-        :param object http_client: bravado.requests_client.RequestsClient
         :param str auth: String to send in the auth header.
         :param proto: Schema where the server resides (http, https)
         :param host: Port where the post request will be sent and the wes server listens at (default 8080)

--- a/wes_client/wes_client_main.py
+++ b/wes_client/wes_client_main.py
@@ -8,10 +8,7 @@ import argparse
 import logging
 import requests
 from requests.exceptions import InvalidSchema, MissingSchema
-from wes_client.util import (run_wf,
-                             wes_client,
-                             modify_jsonyaml_paths)
-from bravado.requests_client import RequestsClient
+from wes_client.util import modify_jsonyaml_paths, WESClient
 
 
 def main(argv=sys.argv[1:]):
@@ -52,26 +49,25 @@ def main(argv=sys.argv[1:]):
         print(u"%s %s" % (sys.argv[0], pkg[0].version))
         exit(0)
 
-    http_client = RequestsClient()
-    client = wes_client(http_client, args.auth, args.proto, args.host)
+    client = WESClient({'auth': args.auth, 'proto': args.proto, 'host': args.host})
 
     if args.list:
-        response = client.ListRuns(page_token=args.page, page_size=args.page_size)
+        response = client.list_runs()  # how to include: page_token=args.page, page_size=args.page_size ?
         json.dump(response.result(), sys.stdout, indent=4)
         return 0
 
     if args.log:
-        response = client.GetRunLog(run_id=args.log)
+        response = client.get_run_log(run_id=args.log)
         sys.stdout.write(response.result()["workflow_log"]["stderr"])
         return 0
 
     if args.get:
-        response = client.GetRunLog(run_id=args.get)
+        response = client.get_run_log(run_id=args.get)
         json.dump(response.result(), sys.stdout, indent=4)
         return 0
 
     if args.info:
-        response = client.GetServiceInfo()
+        response = client.get_service_info()
         json.dump(response.result(), sys.stdout, indent=4)
         return 0
 
@@ -91,13 +87,7 @@ def main(argv=sys.argv[1:]):
         logging.basicConfig(level=logging.INFO)
 
     args.attachments = args.attachments if not args.attachments else args.attachments.split(',')
-    r = run_wf(args.workflow_url,
-               args.job_order,
-               args.attachments,
-               http_client,
-               args.auth,
-               args.proto,
-               args.host)
+    r = client.run(args.workflow_url, args.job_order, args.attachments)
 
     if args.wait:
         logging.info("Workflow run id is %s", r["run_id"])
@@ -105,14 +95,14 @@ def main(argv=sys.argv[1:]):
         sys.stdout.write(r["run_id"] + "\n")
         exit(0)
 
-    r = client.GetRunStatus(run_id=r["run_id"]).result()
+    r = client.get_run_status(run_id=r["run_id"]).result()
     while r["state"] in ("QUEUED", "INITIALIZING", "RUNNING"):
         time.sleep(8)
-        r = client.GetRunStatus(run_id=r["run_id"]).result()
+        r = client.get_run_status(run_id=r["run_id"]).result()
 
     logging.info("State is %s", r["state"])
 
-    s = client.GetRunLog(run_id=r["run_id"]).result()
+    s = client.get_run_log(run_id=r["run_id"]).result()
 
     try:
         # TODO: Only works with Arvados atm

--- a/wes_service/cwl_runner.py
+++ b/wes_service/cwl_runner.py
@@ -173,6 +173,8 @@ class CWLRunnerBackend(WESBackend):
 
     def ListRuns(self, page_size=None, page_token=None, state_search=None):
         # FIXME #15 results don't page
+        if not os.path.exists(os.path.join(os.getcwd(), "workflows")):
+            return {"workflows": [], "next_page_token": ""}
         wf = []
         for l in os.listdir(os.path.join(os.getcwd(), "workflows")):
             if os.path.isdir(os.path.join(os.getcwd(), "workflows", l)):

--- a/wes_service/toil_wes.py
+++ b/wes_service/toil_wes.py
@@ -298,6 +298,8 @@ class ToilBackend(WESBackend):
 
     def ListRuns(self, page_size=None, page_token=None, state_search=None):
         # FIXME #15 results don't page
+        if not os.path.exists(os.path.join(os.getcwd(), "workflows")):
+            return {"workflows": [], "next_page_token": ""}
         wf = []
         for l in os.listdir(os.path.join(os.getcwd(), "workflows")):
             if os.path.isdir(os.path.join(os.getcwd(), "workflows", l)):


### PR DESCRIPTION
This PR implements direct calls to the swagger API using the `requests` library.

- Removed the bravado req.
- Added unittests.
- Old unittests now call via the client.
- Changed the main cli to use the new functions.
