### PR TITLE
Add remote support

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -33,7 +33,7 @@ class IntegrationTest(unittest.TestCase):
         cls.wdl_attachments = ['file://' + os.path.abspath('testdata/md5sum.input')]
 
         # client for the swagger API methods
-        cls.client = WESClient({'auth': '', 'proto': 'http', 'host': 'localhost:8080'})
+        cls.client = WESClient({'auth': '', 'auth_type': None, 'proto': 'http', 'host': 'localhost:8080'})
 
         # manual test (wdl only working locally atm)
         cls.manual = False

--- a/wes_client/util.py
+++ b/wes_client/util.py
@@ -165,7 +165,7 @@ class WESClient(object):
         self.host = service['host']
         auth_param = {'token': 'Authorization',
                       'api_key': 'X-API-KEY',
-                       None: ''} 
+                       None: 'Authorization'} 
         self.param_in = auth_param[service['auth_type']]
 
     def get_service_info(self):

--- a/wes_client/util.py
+++ b/wes_client/util.py
@@ -163,6 +163,10 @@ class WESClient(object):
         self.auth = service['auth']
         self.proto = service['proto']
         self.host = service['host']
+        auth_param = {'token': 'Authorization',
+                      'api_key': 'X-API-KEY',
+                       None: ''} 
+        self.param_in = auth_param[service['auth_type']]
 
     def get_service_info(self):
         """
@@ -178,7 +182,7 @@ class WESClient(object):
         :return: The body of the get result as a dictionary.
         """
         postresult = requests.get("%s://%s/ga4gh/wes/v1/service-info" % (self.proto, self.host),
-                                  headers={"Authorization": self.auth})
+                                  headers={self.param_in: self.auth})
         return wes_reponse(postresult)
 
     def list_runs(self):
@@ -194,7 +198,7 @@ class WESClient(object):
         :return: The body of the get result as a dictionary.
         """
         postresult = requests.get("%s://%s/ga4gh/wes/v1/runs" % (self.proto, self.host),
-                                  headers={"Authorization": self.auth})
+                                  headers={self.param_in: self.auth})
         return wes_reponse(postresult)
 
     def run(self, wf, jsonyaml, attachments):
@@ -214,7 +218,7 @@ class WESClient(object):
         parts = build_wes_request(wf, jsonyaml, attachments)
         postresult = requests.post("%s://%s/ga4gh/wes/v1/runs" % (self.proto, self.host),
                                    files=parts,
-                                   headers={"Authorization": self.auth})
+                                   headers={self.param_in: self.auth})
         return wes_reponse(postresult)
 
     def cancel(self, run_id):
@@ -228,7 +232,7 @@ class WESClient(object):
         :return: The body of the delete result as a dictionary.
         """
         postresult = requests.delete("%s://%s/ga4gh/wes/v1/runs/%s" % (self.proto, self.host, run_id),
-                                     headers={"Authorization": self.auth})
+                                     headers={self.param_in: self.auth})
         return wes_reponse(postresult)
 
     def get_run_log(self, run_id):
@@ -242,7 +246,7 @@ class WESClient(object):
         :return: The body of the get result as a dictionary.
         """
         postresult = requests.get("%s://%s/ga4gh/wes/v1/runs/%s" % (self.proto, self.host, run_id),
-                                  headers={"Authorization": self.auth})
+                                  headers={self.param_in: self.auth})
         return wes_reponse(postresult)
 
     def get_run_status(self, run_id):
@@ -256,5 +260,5 @@ class WESClient(object):
         :return: The body of the get result as a dictionary.
         """
         postresult = requests.get("%s://%s/ga4gh/wes/v1/runs/%s/status" % (self.proto, self.host, run_id),
-                                  headers={"Authorization": self.auth})
+                                  headers={self.param_in: self.auth})
         return wes_reponse(postresult)

--- a/wes_client/util.py
+++ b/wes_client/util.py
@@ -66,38 +66,6 @@ def wf_info(workflow_path):
     return version, file_type.upper()
 
 
-def build_wes_request(workflow_file, json_path, attachments=None):
-    """
-    :param str workflow_file: Path to cwl/wdl file.  Can be http/https/file.
-    :param json_path: Path to accompanying json file.  Currently must be local.
-    :param attachments: Any other files needing to be uploaded to the server.
-
-    :return: A list of tuples formatted to be sent in a post to the wes-server (Swagger API).
-    """
-    workflow_file = "file://" + workflow_file if ":" not in workflow_file else workflow_file
-    json_path = json_path[7:] if json_path.startswith("file://") else json_path
-    wf_version, wf_type = wf_info(workflow_file)
-
-    parts = [("workflow_params", json.dumps(json.load(open(json_path)))),
-             ("workflow_type", wf_type),
-             ("workflow_type_version", wf_version)]
-
-    if workflow_file.startswith("file://"):
-        parts.append(("workflow_attachment", (os.path.basename(workflow_file[7:]), open(workflow_file[7:], "rb"))))
-        parts.append(("workflow_url", os.path.basename(workflow_file[7:])))
-    else:
-        parts.append(("workflow_url", workflow_file))
-
-    if attachments:
-        for attachment in attachments:
-            attachment = attachment[7:] if attachment.startswith("file://") else attachment
-            if ':' in attachment:
-                raise TypeError('Only local files supported for attachment: %s' % attachment)
-            parts.append(("workflow_attachment", (os.path.basename(attachment), open(attachment, "rb"))))
-
-    return parts
-
-
 def modify_jsonyaml_paths(jsonyaml_file):
     """
     Changes relative paths in a json/yaml file to be relative
@@ -124,6 +92,49 @@ def modify_jsonyaml_paths(jsonyaml_file):
                 del d["path"]
 
     visit(input_dict, fixpaths)
+    return json.dumps(input_dict)
+
+
+def build_wes_request(workflow_file, json_path, attachments=None):
+    """
+    :param str workflow_file: Path to cwl/wdl file.  Can be http/https/file.
+    :param json_path: Path to accompanying json file.
+    :param attachments: Any other files needing to be uploaded to the server.
+
+    :return: A list of tuples formatted to be sent in a post to the wes-server (Swagger API).
+    """
+    workflow_file = "file://" + workflow_file if ":" not in workflow_file else workflow_file
+    if json_path.startswith("file://"):
+        json_path = json_path[7:]
+        with open(json_path) as f:
+            wf_params = json.dumps(json.load(f))
+    elif json_path.startswith("http"):
+        wf_params = modify_jsonyaml_paths(json_path)
+    else: 
+        wf_params = json_path
+    wf_version, wf_type = wf_info(workflow_file)
+
+    parts = [("workflow_params", wf_params),
+             ("workflow_type", wf_type),
+             ("workflow_type_version", wf_version)]
+
+    if workflow_file.startswith("file://"):
+        parts.append(("workflow_attachment", (os.path.basename(workflow_file[7:]), open(workflow_file[7:], "rb"))))
+        parts.append(("workflow_url", os.path.basename(workflow_file[7:])))
+    else:
+        parts.append(("workflow_url", workflow_file))
+
+    if attachments:
+        for attachment in attachments:
+            if attachment.startswith("file://"):
+                attachment = attachment[7:] 
+                attach_f = open(attachment, "rb")
+            elif attachment.startswith("http"):
+                attach_f = urlopen(attachment)
+
+            parts.append(("workflow_attachment", (os.path.basename(attachment), attach_f)))
+
+    return parts
 
 
 def expand_globs(attachments):


### PR DESCRIPTION
Includes a couple minor changes to extend support for remote files and service endpoints:
+ uses `urllib` to open workflow params (`jsonyaml`) or attachments from http(s) URL; the former is read and added to the request as JSON string, the latter are added as file sockets
+ modifies the `WESClient` class to allow specification of 'auth_type' (e.g., for endpoints that require 'X-API-KEY' in the header instead of 'Authorization')

There might be a cleaner way to handle the first change, but seems to be working for now.