### PR TITLE
Rename workflow_log to run_log to conform to latest WES draft.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.pypi.rst") as readmeFile:
     long_description = readmeFile.read()
 
 setup(name='wes-service',
-      version='2.7',
+      version='2.8',
       description='GA4GH Workflow Execution Service reference implementation',
       long_description=long_description,
       author='GA4GH Containers and Workflows task team',

--- a/wes_client/wes_client_main.py
+++ b/wes_client/wes_client_main.py
@@ -49,11 +49,13 @@ def main(argv=sys.argv[1:]):
         print(u"%s %s" % (sys.argv[0], pkg[0].version))
         exit(0)
 
-    if ": " in args.auth:
-        sp = args.auth.split(": ")
-        auth = {sp[0]: sp[1]}
-    else:
-        auth = {"Authorization": auth}
+    auth = {}
+    if args.auth:
+        if ": " in args.auth:
+            sp = args.auth.split(": ")
+            auth[sp[0]] = sp[1]
+        else:
+            auth["Authorization"] = args.auth
 
     client = WESClient({'auth': auth, 'proto': args.proto, 'host': args.host})
 
@@ -85,7 +87,7 @@ def main(argv=sys.argv[1:]):
         logging.error("Missing json/yaml file.")
         return 1
 
-    modify_jsonyaml_paths(args.job_order)
+    job_order = modify_jsonyaml_paths(args.job_order)
 
     if args.quiet:
         logging.basicConfig(level=logging.WARNING)
@@ -93,7 +95,7 @@ def main(argv=sys.argv[1:]):
         logging.basicConfig(level=logging.INFO)
 
     args.attachments = "" if not args.attachments else args.attachments.split(',')
-    r = client.run(args.workflow_url, args.job_order, args.attachments)
+    r = client.run(args.workflow_url, job_order, args.attachments)
 
     if args.wait:
         logging.info("Workflow run id is %s", r["run_id"])

--- a/wes_service/arvados_wes.py
+++ b/wes_service/arvados_wes.py
@@ -24,8 +24,9 @@ def get_api(authtoken=None):
         if not connexion.request.headers.get('Authorization'):
             raise MissingAuthorization()
         authtoken = connexion.request.headers['Authorization']
-        if authtoken.startswith("Bearer ") or authtoken.startswith("OAuth2 "):
-            authtoken = authtoken[7:]
+        if not authtoken.startswith("Bearer ") or authtoken.startswith("OAuth2 "):
+            raise ValueError("Authorization token must start with 'Bearer '")
+        authtoken = authtoken[7:]
     return arvados.api_from_config(version="v1", apiconfig={
         "ARVADOS_API_HOST": os.environ["ARVADOS_API_HOST"],
         "ARVADOS_API_TOKEN": authtoken,

--- a/wes_service/arvados_wes.py
+++ b/wes_service/arvados_wes.py
@@ -109,10 +109,9 @@ class ArvadosBackend(WESBackend):
         }
 
     def log_for_run(self, run_id, message):
-        api.logs().create(body={"log": {"object_uuid": run_id,
-                                        "event_type": "stderr",
-                                        "properties": {"text": message}}}).execute()
-
+        get_api().logs().create(body={"log": {"object_uuid": run_id,
+                                              "event_type": "stderr",
+                                              "properties": {"text": message}}}).execute()
 
     def invoke_cwl_runner(self, cr_uuid, workflow_url, workflow_params,
                           env, project_uuid,
@@ -209,12 +208,10 @@ class ArvadosBackend(WESBackend):
             containers_map[container["uuid"]] = container
         else:
             container = {
-                "state": "Queued" if request["priority"] > 0 else "Cancelled"
+                "state": "Queued" if request["priority"] > 0 else "Cancelled",
                 "exit_code": None,
                 "log": None
             }
-            else:
-                pass
             tasks = []
             containers_map = {}
             task_reqs = []

--- a/wes_service/arvados_wes.py
+++ b/wes_service/arvados_wes.py
@@ -116,8 +116,8 @@ class ArvadosBackend(WESBackend):
 
     def log_for_run(self, run_id, message, authtoken=None):
         get_api(authtoken).logs().create(body={"log": {"object_uuid": run_id,
-                                              "event_type": "stderr",
-                                              "properties": {"text": message+"\n"}}}).execute()
+                                                       "event_type": "stderr",
+                                                       "properties": {"text": message+"\n"}}}).execute()
 
     def invoke_cwl_runner(self, cr_uuid, workflow_url, workflow_params,
                           env, project_uuid,

--- a/wes_service/arvados_wes.py
+++ b/wes_service/arvados_wes.py
@@ -208,7 +208,13 @@ class ArvadosBackend(WESBackend):
             containers_map = {c["uuid"]: c for c in tasks}
             containers_map[container["uuid"]] = container
         else:
-            container = {"state": "Queued", "exit_code": None, "log": None}
+            container = {
+                "state": "Queued" if request["priority"] > 0 else "Cancelled"
+                "exit_code": None,
+                "log": None
+            }
+            else:
+                pass
             tasks = []
             containers_map = {}
             task_reqs = []

--- a/wes_service/cwl_runner.py
+++ b/wes_service/cwl_runner.py
@@ -142,7 +142,7 @@ class Workflow(object):
             "run_id": self.run_id,
             "request": request,
             "state": state,
-            "workflow_log": {
+            "run_log": {
                 "cmd": [""],
                 "start_time": "",
                 "end_time": "",

--- a/wes_service/toil_wes.py
+++ b/wes_service/toil_wes.py
@@ -158,7 +158,7 @@ class ToilWorkflow(object):
             "run_id": self.run_id,
             "request": request,
             "state": state,
-            "workflow_log": {
+            "run_log": {
                 "cmd": cmd,
                 "start_time": starttime,
                 "end_time": endtime,

--- a/wes_service/util.py
+++ b/wes_service/util.py
@@ -58,7 +58,8 @@ class WESBackend(object):
                     v.save(dest)
                     body[k] = "file://%s" % tempdir  # Reference to temp working dir.
                 elif k in ("workflow_params", "tags", "workflow_engine_parameters"):
-                    body[k] = json.loads(v.read())
+                    content = v.read()
+                    body[k] = json.loads(content)
                 else:
                     body[k] = v.read()
 


### PR DESCRIPTION
* Rename workflow_log to run_log to conform to latest WES draft.

* Log attachment staging and workflow_url to assist in debugging.

* Fix bug in wes-client to provide correct type for 'auth' parameter
  of WESClient object.

* Generalize --auth parameter of wes-client to support specifying
  alternate header.